### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/telepathy-ring.spec
+++ b/rpm/telepathy-ring.spec
@@ -23,8 +23,8 @@ BuildRequires:  pkgconfig(telepathy-glib) >= 0.11.7
 BuildRequires:  pkgconfig(mission-control-plugins)
 BuildRequires:  pkgconfig(libngf0) >= 0.24
 BuildRequires:  pkgconfig(libdbusaccess)
-BuildRequires:  python3-devel
-BuildRequires:  systemd
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(systemd)
 
 %description
 %{summary}.


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>